### PR TITLE
Add support for installing fixed versions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,8 +13,14 @@ provisioner:
   salt_install: bootstrap
   salt_bootstrap_url: https://bootstrap.saltstack.com
   salt_version: latest
-  salt_pillar_root: pillar.example
-  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'info' %>
+  pillars-from-files:
+    <%= formula_name %>.sls: pillar.example
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - <%= formula_name %>
+  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'debug' %>
   formula: <%= formula_name %>
   state_top:
     base:

--- a/mysql/client.sls
+++ b/mysql/client.sls
@@ -2,10 +2,29 @@
 # vim: ft=sls
 include:
   - .repo
+  - mysql.custom_version
 
 {% from "mysql/defaults.yaml" import rawmap with context %}
 {%- set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:lookup')) %}
 
 mysql-pkg:
+{# We want to install a custom version and it's not in repository #}
+{%- if mysql.version is defined and salt['cmd.retcode']('apt-cache madison ' ~ mysql.pkg_prefix ~ '-' ~ mysql.major_version ~ ' | grep -qP \'(^|\s)\K' ~ mysql.pkg_prefix ~ '-' ~ mysql.major_version ~ '(?=\s|$)\' | grep -qP \'(^|\s)\K' ~ mysql.version ~ '-1(?=\s|$)\'', python_shell=True) == 1 %}
+{%- set libperconaserverclient_version = salt['cmd.run_stdout']('curl -sL ' ~ mysql.percona_url ~ ' | grep -oP "\/downloads[^\s>]+libperconaserverclient([0-9|\.]*)_[^\s>]+\.' ~ grains['oscodename'] | lower ~ '_' ~ mysql.os_arch ~ '\.deb" | sed -n "s/\/downloads\(.*\)libperconaserverclient\([0-9|\.]*\)\_\(.*\)/\\2/p"', python_shell=True) %}
   pkg.installed:
-    - name: {{ mysql.client }}
+    - sources:
+      - {{ mysql.pkg_prefix }}-common-{{ mysql.major_version }}: /tmp/percona/{{ mysql.pkg_prefix }}-common-{{ mysql.version_suffix_w_major }}
+      - libperconaserverclient{{ libperconaserverclient_version }}: /tmp/percona/libperconaserverclient{{ libperconaserverclient_version }}_{{ mysql.version_suffix }}
+      - libperconaserverclient{{ libperconaserverclient_version }}-dev: /tmp/percona/libperconaserverclient{{ libperconaserverclient_version }}-dev_{{ mysql.version_suffix }}
+      - {{ mysql.pkg_prefix }}-client-{{ mysql.major_version }}: /tmp/percona/{{ mysql.pkg_prefix }}-client-{{ mysql.version_suffix_w_major }}
+      {%- if mysql.major_version == '5.6' %} {# Percona removed packages like percona-server-client-5.6_5.6.36-82.0-1.trusty_amd64.deb in 5.7 release #}
+      - {{ mysql.pkg_prefix }}-client: /tmp/percona/{{ mysql.pkg_prefix }}-client_{{ mysql.version_suffix }}
+      {% endif %}
+    - require:
+      - sls: mysql.custom_version
+{% else %}
+  pkg.installed:
+    - name: {{ mysql.pkg_prefix }}-client-{{ mysql.major_version }}
+    - require:
+      - debconf: mysql_debconf
+{% endif %} {# if mysql.version is defined... #}

--- a/mysql/custom_version.sls
+++ b/mysql/custom_version.sls
@@ -1,0 +1,37 @@
+{% from "mysql/defaults.yaml" import rawmap with context %}
+
+include:
+  - mysql.repo
+
+{% set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql:lookup')) %}
+
+{# We want to install a custom version and it's not in repository #}
+{%- if (mysql.version is defined and mysql.version != '') and salt['cmd.retcode']('apt-cache madison ' ~ mysql.pkg_prefix ~ '-' ~ mysql.major_version ~ ' | grep -qP \'(^|\s)\K' ~ mysql.pkg_prefix ~ '-' ~ mysql.major_version ~ '(?=\s|$)\' | grep -qP \'(^|\s)\K' ~ mysql.version ~ '-1(?=\s|$)\'', python_shell=True) == 1 %}
+percona-custom-version:
+  pkg.latest:
+    - pkgs:
+      - zlib1g-dev
+      - libdbi-perl
+      - libdbd-mysql-perl
+      - libaio1
+      - libwrap0
+      - psmisc
+      - curl
+
+{%- set percona_tarball_url = salt['cmd.run_stdout']('curl -sL ' ~ mysql.percona_url ~ ' | grep -oP "\/downloads[^\s>]+' ~ mysql.tarball_suffix ~ '\.tar" | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
+
+  archive.extracted:
+    - name: /tmp/percona
+    - source: {{ percona_tarball_url }}
+    - enforce_toplevel: False
+    - skip_verify: True
+    - overwrite: True
+    - trim_output: True
+    - keep: True
+    - if_missing: /tmp/percona
+    - require:
+      - pkg: percona-custom-version
+    - require_in:
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
+{% endif %}

--- a/mysql/defaults.yaml
+++ b/mysql/defaults.yaml
@@ -2,21 +2,47 @@
 # vim: ft=yaml
 # SET ALL PARAMS IN CONFIG SECTION USING UNDERSCORE, NOT HYPHEN
 # so that it works correctly
-{% set version = salt['pillar.get']('percona.version', '5.6') %}
+{%- if salt['pillar.get']('mysql:version') is defined and salt['pillar.get']('mysql:version') != '' %}
+{%- set version = salt['pillar.get']('mysql:version') %}
+{%- set major_version = version.split('.')[0] ~ '.' ~ version.split('.')[1] %}
+{#- https://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-5.6.31-77.0/binary/debian/trusty/x86_64/ -#}
+{%- set tarball_os_arch = 'x86_64' if (grains['cpuarch']=='x86_64' or grains['cpuarch']=='amd64') else 'i386' %}
+{%- set tarball_suffix = "-{{ grains['oscodename'] }}-{{ os_arch }}-bundle" %}
+{%- set os_arch = 'amd64' if (grains['cpuarch']=='x86_64' or grains['cpuarch']=='amd64') else 'i386' %}
+{# percona-server-client-5.6_5.6.31-77.0-1.trusty_amd64.deb #}
+{%- set version_suffix_w_major = "{{ mysql.major_version }}_{{ mysql.version }}-1.{{ grains['oscodename'] }}_{{ os_arch }}.deb" %}
+{# percona-server-client_5.6.31-77.0-1.trusty_amd64.deb #}
+{%- set version_suffix = "{{ mysql.version }}-1.{{ grains['oscodename'] }}_{{ os_arch }}.deb" %}
+{%- set percona_url = "https://www.percona.com/downloads/Percona-Server-" ~ major_version ~ "/Percona-Server-" ~ version ~ "/binary/" ~ grains['os_family'] | lower ~ "/" ~ grains['oscodename'] | lower ~ "/" ~ tarball_os_arch | lower ~ "/" %}
+{% else %}
+{%- set major_version = '5.6' %}
+{% endif %}
 {% set innodb_buffer_pool_size = salt['grains.get']('mem_total', '1024') * 0.6 %}
 {% load_yaml as rawmap %}
 
 Ubuntu:
-  client: percona-server-client-{{ version }}
-  server: percona-server-server-{{ version }}
-  server_short: percona-server-server
+  pkg_prefix: percona-server
+  major_version: {{ major_version }}
+{%- if salt['pillar.get']('mysql:version') is defined and salt['pillar.get']('mysql:version') != '' %}
+  version: {{ version }}
+  tarball_os_arch: {{ 'x86_64' if grains['cpuarch']=='x86_64' or grains['cpuarch']=='amd64' else 'i386' }}
+  tarball_suffix: "-{{ grains['oscodename'] }}-{{ tarball_os_arch }}-bundle"
+  os_arch: {{ 'amd64' if grains['cpuarch']=='x86_64' or grains['cpuarch']=='amd64' else 'i386' }}
+  version_suffix_w_major: {{ major_version }}_{{ version }}-1.{{ grains['oscodename'] }}_{{ os_arch }}.deb
+  version_suffix: {{ version }}-1.{{ grains['oscodename'] }}_{{ os_arch }}.deb
+  percona_url: {{ percona_url }}
+{% endif %}
   service: mysql
   python: python-mysqldb
   debconf_utils: debconf-utils
   defaults_extra_file: /etc/mysql/debian.cnf
   dev: libmysqlclient-dev
   config:
+    {%- if major_version == '5.7' %}
+    file: /etc/mysql/percona-server.conf.d/percona.cnf
+    {% else %}
     file: /etc/mysql/conf.d/percona.cnf
+    {% endif %}
     sections:
       client:
         default_character_set: utf8
@@ -29,7 +55,9 @@ Ubuntu:
         bind_address: 0.0.0.0
         character_set_server: utf8
         default_storage_engine: InnoDB
-        pid_file: /var/run/mysqld/mysqld.pid
+        # Percona doesn't start if you don't have a pid-file argument
+        # pid_file doesn't work either
+        pid-file: /var/run/mysqld/mysqld.pid
         socket: /var/run/mysqld/mysqld.sock
         #ssl_ca: /etc/mysql/cacert.pem
         #ssl_cert: /etc/mysql/server.pem
@@ -37,7 +65,7 @@ Ubuntu:
         user: mysql
         skip_name_resolve: noarg_present
         key_buffer_size: 32M
-        myisam_recover: FORCE,BACKUP
+        myisam_recover_options: FORCE,BACKUP
         innodb: FORCE
         innodb_strict_mode: 1
         max_allowed_packet: 16M

--- a/mysql/repo.sls
+++ b/mysql/repo.sls
@@ -1,5 +1,47 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
+{% from "mysql/defaults.yaml" import rawmap with context %}
+{% set mysql = salt['grains.filter_by'](rawmap, grain='os', merge=salt['pillar.get']('mysql')) %}
+
+{%- if mysql.version is defined %}
+{#
+Versions are like: 5.6.36-82.0-1.precise
+We expect them in format: 5.6.36-82.0-1 and we add the release info
+#}
+
+{%- set libperconaserverclient_version = salt['cmd.run_stdout']('curl -sL ' ~ mysql.percona_url ~ ' | grep -oP "\/downloads[^\s>]+libperconaserverclient([0-9|\.]*)_[^\s>]+\.' ~ grains['oscodename'] | lower ~ '_' ~ mysql.os_arch ~ '\.deb" | sed -n "s/\/downloads\(.*\)libperconaserverclient\([0-9|\.]*\)\_\(.*\)/\\2/p"', python_shell=True) %}
+
+/etc/apt/preferences.d/percona:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 0644
+    - contents: |
+        Package: percona-server*
+        Pin: version {{ mysql.version }}-1.{{ grains['oscodename'] }}
+        Pin-Priority: 1001
+    - require_in:
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
+
+/etc/apt/preferences.d/libpercona:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 0644
+    - contents: |
+        Package: libperconaserverclient{{ libperconaserverclient_version }}
+        Pin: version {{ mysql.version }}-1.{{ grains['oscodename'] }}
+        Pin-Priority: 1001
+
+        Package: libperconaserverclient{{ libperconaserverclient_version }}-dev
+        Pin: version {{ mysql.version }}-1.{{ grains['oscodename'] }}
+        Pin-Priority: 1001
+    - require_in:
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
+
+{% else %}
 
 {%- if grains['os_family'] == 'Debian' %}
 percona-repository:
@@ -13,12 +55,12 @@ percona-repository:
     - gpgcheck: 1
     - clean_file: true
     - require_in:
-      - percona-server-pkg
-      - mysql-pkg
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
 
 percona-repository-src:
   pkgrepo.managed:
-    - humanname: Percona Repository
+    - humanname: Percona Repository SRC
     - name: deb-src http://repo.percona.com/apt {{ grains['oscodename'] }} main
     - dist: {{ grains['oscodename'] }}
     - file: /etc/apt/sources.list.d/percona-src.list
@@ -26,6 +68,9 @@ percona-repository-src:
     - keyserver: keyserver.ubuntu.com
     - gpgcheck: 1
     - clean_file: true
+    - require_in:
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
 {%- elif grains['os_family'] == 'RedHat' %}
 percona-repository:
     - humanname: Percona Repository
@@ -34,6 +79,8 @@ percona-repository:
     - gpgcheck: 1
     - gpgkey: https://www.percona.com/downloads/RPM-GPG-KEY-percona
     - require_in:
-      - percona-server-pkg
-      - mysql-pkg
+      - pkg: percona-server-pkg
+      - pkg: mysql-pkg
+{% endif %}
+
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,120 +1,9 @@
 mysql:
-  global:
-    client-server:
-      default_character_set: utf8
 
-  clients:
-    mysql:
-      default_character_set: utf8
-    mysqldump:
-      default_character_set: utf8
-
-  library:
-    client:
-      default_character_set: utf8
-
-  server:
-    # Use this account for database admin (defaults to root)
-    root_user: 'admin'
-    # root_password: '' - to have root@localhost without password
-    root_password: 'somepass'
-    root_password_hash: '*13883BDDBE566ECECC0501CDE9B293303116521A'
-    user: mysql
-    # If you only manage the dbs and users and the server is on
-    # another host
-    host: 123.123.123.123
-    # my.cnf sections changes
-    mysqld:
-      # you can use either underscore or hyphen in param names
-      bind-address: 0.0.0.0
-      log_bin: /var/log/mysql/mysql-bin.log
-      datadir: /var/lib/mysql
-      port: 3307
-      binlog_do_db: foo
-      auto_increment_increment: 5
-      binlog-ignore-db:
-       - mysql
-       - sys
-       - information_schema
-       - performance_schema
-    mysql:
-      # my.cnf param that not require value
-      no-auto-rehash: noarg_present
-
-  salt_user:
-    salt_user_name: 'salt'
-    salt_user_password: 'someotherpass'
-    grants:
-      - 'all privileges'
-
-  # Manage databases
-  database:
-    - foo
-    - bar
-  schema:
-    foo:
-      load: True
-      source: salt://mysql/files/foo.schema
-    bar:
-      load: False
-    baz:
-      load: True
-      source: salt://mysql/files/baz.schema.tmpl
-      template: jinja
-    qux:
-      load: True
-      source: salt://mysql/files/qux.schema.tmpl
-      template: jinja
-      context:
-        encabulator: Turbo
-        girdlespring: differential
-    quux:
-      load: True
-      source: salt://mysql/files/qux.schema.tmpl
-      template: jinja
-      context:
-        encabulator: Retro
-        girdlespring: integral
-
-  # Manage users
-  # you can get pillar for existing server using scripts/import_users.py script
-  user:
-    frank:
-      password: 'somepass'
-      host: localhost
-      databases:
-        - database: foo
-          grants: ['select', 'insert', 'update']
-        - database: bar
-          grants: ['all privileges']
-    bob:
-      password_hash: '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'
-      host: localhost
-      ssl: True
-      ssl-X509: True
-      ssl-SUBJECT: Subject
-      ssl-ISSUER: Name
-      ssl-CIPHER: Cipher
-      databases:
-        - database: foo
-          grants: ['all privileges']
-          grant_option: True
-        - database: bar
-          table: foobar
-          grants: ['select', 'insert', 'update', 'delete']
-    nopassuser:
-      password: ~
-      host: localhost
-      databases: []
-    application:
-      password: 'somepass'
-      mine_hosts:
-        target: "G@role:database and *.example.com"
-        function: "network.get_hostname"
-        expr_form: compound
-      databases:
-        - database: foo
-          grants: ['select', 'insert', 'update']
+  # Ubuntu package versions are like: 5.6.36-82.0-1.precise (Please remove -1.precise)
+  # We configure the release version in repo.sls
+  # If not defined we default major version to 5.6
+  #version: 5.6.31-77.0
 
   # Override any names defined in map.jinja
 #  lookup:
@@ -127,4 +16,3 @@ mysql:
   dev:
     # Install dev package - defaults to False
     install: False
-

--- a/test/integration/default/serverspec/mysql_spec.rb
+++ b/test/integration/default/serverspec/mysql_spec.rb
@@ -10,11 +10,27 @@ mysql_query = "mysql --defaults-extra-file=/root/.my.cnf mysql -sN -e"
 describe "MySQL" do
   # ===== MySQL critical tests ======
   it "server package is installed" do
-    expect(package(mysql['server'])).to be_installed
+    expect(package("#{mysql['pkg_prefix']}-server-#{mysql['major_version']}")).to be_installed
   end
 
   it "client package is installed" do
-    expect(package(mysql['client'])).to be_installed
+    expect(package("#{mysql['pkg_prefix']}-client-#{mysql['major_version']}")).to be_installed
+  end
+
+  if mysql['version'] then
+    if mysql['major_version'] == '5.6' then
+      version_suffix = ''
+    else
+      version_suffix = "-#{mysql['major_version']}"
+    end
+
+    it "server package version is #{mysql['version']}-1.#{$codename}" do
+      expect(package("#{mysql['pkg_prefix']}-server#{version_suffix}")).to be_installed.with_version("#{mysql['version']}-1.#{$codename}")
+    end
+
+    it "client package version is #{mysql['version']}-1.#{$codename}" do
+      expect(package("#{mysql['pkg_prefix']}-client#{version_suffix}")).to be_installed.with_version("#{mysql['version']}-1.#{$codename}")
+    end
   end
 
   it "is listening on port #{mysql['config']['sections']['mysqld']['port'] || 3306}" do

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -7,6 +7,7 @@ system "salt-call --local --config-dir=/tmp/kitchen/etc/salt -l quiet cp.get_tem
 
 # Configure OS specific parameters
 if ['debian', 'ubuntu'].include?(os[:family])
+  $codename = `cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d\= -f 2 | tr -d '\n\r'`
   unless File.exists?('/bin/netstat')
     system "apt-get install -y net-tools"
   end


### PR DESCRIPTION
This PR addresses a couple of things:

- Fix the pillar configuration for kitchen-salt
- Workaround for the `pid-file` setting not allowing Percona to start (Specially in Xenial - 16.04)
- Remove not used Pillar data
- Fix some wrong dependencies in repo.sls
- Add support for installing specific versions by downloading tarball from Percona website and install them in the right order.