### PR TITLE
Fix MySQL init script for 5.6 and other improvements

### DIFF
--- a/percona/custom_version.sls
+++ b/percona/custom_version.sls
@@ -19,7 +19,6 @@ percona-custom-version:
       - curl
 
 {%- set percona_tarball_url = salt['cmd.run_stdout']('curl -sL ' ~ mysql.percona_url ~ ' | grep -oP "\/downloads[^\s>]+' ~ mysql.tarball_suffix ~ '\.tar" | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
-
   archive.extracted:
     - name: /tmp/percona
     - source: {{ percona_tarball_url }}

--- a/percona/monitoring/cacti.sls
+++ b/percona/monitoring/cacti.sls
@@ -3,7 +3,9 @@
 {%- set percona_cacti_plugin_url = 'https://www.percona.com/downloads/percona-monitoring-plugins/LATEST/binary/' ~ grains['os_family'] | lower ~ '/' ~ grains['oscodename'] ~ '/' ~ mysql.tarball_os_arch ~ '/' %}
 {%- set percona_cacti_plugin_pkg_url = salt['cmd.run_stdout']('curl -sL ' ~ percona_cacti_plugin_url ~ ' | grep -oP "\/downloads[^\s>]+\.deb" | grep -i cacti | tail -1 | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
 
+{%- if 1 == salt['cmd.retcode']("dpkg-query -f '${Status}' -W percona-cacti-templates | grep -E '^(install|hold) ok installed$'", python_shell=True) %}
 percona-cacti-templates:
   pkg.installed:
     - sources:
       - percona-cacti-templates: {{ percona_cacti_plugin_pkg_url }}
+{% endif %}

--- a/percona/monitoring/nagios.sls
+++ b/percona/monitoring/nagios.sls
@@ -3,7 +3,9 @@
 {%- set percona_nagios_plugin_url = 'https://www.percona.com/downloads/percona-monitoring-plugins/LATEST/binary/' ~ grains['os_family'] | lower ~ '/' ~ grains['oscodename'] ~ '/' ~ mysql.tarball_os_arch ~ '/' %}
 {%- set percona_nagios_plugin_pkg_url = salt['cmd.run_stdout']('curl -sL ' ~ percona_nagios_plugin_url ~ ' | grep -oP "\/downloads[^\s>]+\.deb" | grep -i nagios | tail -1 | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
 
+{%- if 1 == salt['cmd.retcode']("dpkg-query -f '${Status}' -W percona-nagios-plugins | grep -E '^(install|hold) ok installed$'", python_shell=True) %}
 percona-nagios-plugins:
   pkg.installed:
     - sources:
       - percona-nagios-plugins: {{ percona_nagios_plugin_pkg_url }}
+{% endif %}

--- a/percona/monitoring/zabbix.sls
+++ b/percona/monitoring/zabbix.sls
@@ -3,7 +3,9 @@
 {%- set percona_zabbix_plugin_url = 'https://www.percona.com/downloads/percona-monitoring-plugins/LATEST/binary/' ~ grains['os_family'] | lower ~ '/' ~ grains['oscodename'] ~ '/' ~ mysql.tarball_os_arch ~ '/' %}
 {%- set percona_zabbix_plugin_pkg_url = salt['cmd.run_stdout']('curl -sL ' ~ percona_zabbix_plugin_url ~ ' | grep -oP "\/downloads[^\s>]+\.deb" | grep -i zabbix | tail -1 | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
 
+{%- if 1 == salt['cmd.retcode']("dpkg-query -f '${Status}' -W percona-zabbix-templates | grep -E '^(install|hold) ok installed$'", python_shell=True) %}
 percona-zabbix-templates:
   pkg.installed:
     - sources:
       - percona-zabbix-templates: {{ percona_zabbix_plugin_pkg_url }}
+{% endif %}

--- a/percona/server/config.sls
+++ b/percona/server/config.sls
@@ -21,17 +21,15 @@ mysql_config:
 {# If you use old 5.6 versions with a big database service start will report
 failure on start due to hardcoded timeout #}
 {# https://bugs.launchpad.net/percona-server/+bug/1434022 #}
-{%- if mysql.major_version == '5.6' %}
+{%- if mysql.major_version|string == '5.6' %}
 mysql_init_script:
   file.managed:
     - name: /etc/init.d/mysql
     - source: https://raw.githubusercontent.com/percona/percona-server/5.6/build-ps/debian/percona-server-server-5.6.mysql.init
+    - skip_verify: True
     - user: root
     - group: root
     - mode: 0755
-  module.run:
-    - name: service.restart
-    - m_name: {{ mysql.service }}
-    - watch:
-      - file: mysql_init_script
+    - watch_in:
+      - file: mysql_config
 {% endif %}

--- a/percona/server/install.sls
+++ b/percona/server/install.sls
@@ -40,10 +40,6 @@ percona-server-pkg:
       {% endif %}
     - require:
       - sls: percona.custom_version
-        # Download all Percona software and install from standalone .deb files
-        #wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.3/binary/debian/trusty/x86_64/percona-xtrabackup-24_2.4.3-1.trusty_amd64.deb
-        #wget https://www.percona.com/downloads/percona-toolkit/2.2.18/deb/percona-toolkit_2.2.18-1_all.deb
-        #wget https://www.percona.com/downloads/percona-monitoring-plugins/1.1.6/percona-nagios-plugins_1.1.6-1_all.deb
 {% else %}
   pkg.installed:
     - name: {{ mysql.pkg_prefix }}-server-{{ mysql.major_version }}

--- a/percona/toolkit.sls
+++ b/percona/toolkit.sls
@@ -3,7 +3,9 @@
 {%- set percona_toolkit_url = 'https://www.percona.com/downloads/percona-toolkit/LATEST/binary/' ~ grains['os_family'] | lower ~ '/' ~ grains['oscodename'] ~ '/' ~ mysql.tarball_os_arch ~ '/' %}
 {%- set percona_toolkit_pkg_url = salt['cmd.run_stdout']('curl -sL ' ~ percona_toolkit_url ~ ' | grep -oP "\/downloads[^\s>]+\.deb" | tail -1 | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
 
+{%- if 1 == salt['cmd.retcode']("dpkg-query -f '${Status}' -W percona-toolkit | grep -E '^(install|hold) ok installed$'", python_shell=True) %}
 percona-toolkit:
   pkg.installed:
     - sources:
       - percona-toolkit: {{ percona_toolkit_pkg_url }}
+{% endif %}

--- a/percona/xtrabackup.sls
+++ b/percona/xtrabackup.sls
@@ -4,7 +4,9 @@
 {%- set percona_xtrabackup_pkg_url = salt['cmd.run_stdout']('curl -sL ' ~ percona_xtrabackup_url ~ ' | grep -oP "\/downloads[^\s>]+percona-xtrabackup-([0-9])+[^\s]+.' ~ grains['oscodename'] ~ '_' ~ mysql.os_arch ~ '\.deb" | tail -1 | sed -e "s/^/https\:\/\/www.percona.com/"', python_shell=True) %}
 {%- set percona_xtrabackup_version = salt['cmd.run_stdout']('echo ' ~ percona_xtrabackup_pkg_url ~ ' | grep -oP "percona-xtrabackup-([0-9]+)"', python_shell=True) %}
 
+{%- if 1 == salt['cmd.retcode']("dpkg-query -f '${Status}' -W " ~ percona_xtrabackup_version ~ " | grep -E '^(install|hold) ok installed$'", python_shell=True) %}
 {{ percona_xtrabackup_version }}:
   pkg.installed:
     - sources:
       - {{ percona_xtrabackup_version }}: {{ percona_xtrabackup_pkg_url }}
+{% endif -%}


### PR DESCRIPTION
This PR does the following:

- Fix the MySQL init script configuration state (It was not running because `mysql.major_version` wasn't treated as a string).
- Removed not longer needed comments.
- Improvement for not downloading packages for xtrabackup, monitoring and toolkit if it's already installed making subsequent high states faster.