### PR TITLE
Use loose prefix for default_character_set to avoid issues with mysqlbinlog

### DIFF
--- a/percona/defaults.yaml
+++ b/percona/defaults.yaml
@@ -50,7 +50,7 @@ Ubuntu:
     {% endif %}
     sections:
       client:
-        default_character_set: utf8
+        loose_default_character_set: utf8
         port: 3306
         socket: /var/run/mysqld/mysqld.sock
       mysqld_safe:


### PR DESCRIPTION
See https://bugs.mysql.com/bug.php?id=11673