### PR TITLE
fix 'missing mysql_config module' issue

### DIFF
--- a/percona/server/config.sls
+++ b/percona/server/config.sls
@@ -12,14 +12,9 @@ mysql_config:
     - user: root
     - group: root
     - mode: 644
-  module.run:
-{% if grains['saltversion'] < '2017.7.0' %}
-    - name: service.restart
-    - m_name: {{ mysql.service }}
-{% else %}
-    - service.restart:
-      - name: {{ mysql.service }}
-{% endif %}
-    - onchanges:
+  service.running:
+    - name: {{ mysql.service }}
+    - enable: True
+    - full_restart: True
+    - watch:
       - file: mysql_config
-


### PR DESCRIPTION
salt is returning:
```
----------
          ID: mysql_config
    Function: module.run
      Result: False
     Comment: Module function mysql_config is not available
     Started: 21:25:32.375747
    Duration: 1.773 ms
     Changes:
----------
```
The intention of this code is to restart mysql service if configuration file changes. It's not about `mysql_config` command or python module.